### PR TITLE
Limit all lines to a maximum of 79 characters.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -15,7 +15,7 @@ set autoindent
 
 " Highlight lines with more than 80 characters
 highlight OverLength ctermbg=red ctermfg=white guibg=#592929
-match OverLength /\%81v.\+/
+match OverLength /\%80v.\+/
 
 " Pressing Enter insert new line without entering edit mode
 map <S-Enter> O<Esc>


### PR DESCRIPTION
Assuming we want to be pep8-compliant:
https://www.python.org/dev/peps/pep-0008/#maximum-line-length

Before (bad):
![last_character](https://cloud.githubusercontent.com/assets/2227806/11450009/424ac0f4-955a-11e5-93fe-a3eb51395492.png)
You would expect a flag on this last character, because then the end of line is out of range:
 ![end_of_line](https://cloud.githubusercontent.com/assets/2227806/11450010/4663570a-955a-11e5-9ea1-8612adcffcb2.png)

After:
![after_last_character](https://cloud.githubusercontent.com/assets/2227806/11450022/c72fa622-955a-11e5-92d5-a6512c5cb1aa.png)
It's flagged!

The longest line should look like this:
![good_last_character](https://cloud.githubusercontent.com/assets/2227806/11450026/f42d5e26-955a-11e5-91fa-6b2a39dcf065.png) ![good_end_of_line](https://cloud.githubusercontent.com/assets/2227806/11450028/f816a560-955a-11e5-8721-c1e9c8dc0eed.png) :baby_chick: 

Cheers
